### PR TITLE
fix(text-clean): preserve CJK characters and newlines in cleanForG2

### DIFF
--- a/glasses/text-clean.ts
+++ b/glasses/text-clean.ts
@@ -1,6 +1,10 @@
 /**
  * Text cleaning utilities for G2 glasses display.
  *
+ * The G2 supports basic Latin, Latin-1 Supplement, common symbols, and CJK.
+ * These helpers strip emojis, unsupported Unicode, and normalize whitespace
+ * so text renders cleanly on the monospace G2 display.
+ *
  * Usage:
  *   import { cleanForG2, normalizeWhitespace } from 'even-toolkit/text-clean';
  *   const safe = cleanForG2('Hello 🌍 World!');  // "Hello World!"
@@ -9,27 +13,14 @@
 // Match emoji ranges + misc symbols + dingbats + variation selectors
 const EMOJI_RE = /[\u{1F600}-\u{1F64F}\u{1F300}-\u{1F5FF}\u{1F680}-\u{1F6FF}\u{1F1E0}-\u{1F1FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}\u{FE00}-\u{FE0F}\u{200D}\u{20E3}\u{E0020}-\u{E007F}\u{1F900}-\u{1F9FF}\u{1FA00}-\u{1FA6F}\u{1FA70}-\u{1FAFF}\u{2702}-\u{27B0}\u{231A}-\u{231B}\u{23E9}-\u{23F3}\u{23F8}-\u{23FA}\u{25AA}-\u{25AB}\u{25B6}\u{25C0}\u{25FB}-\u{25FE}\u{2614}-\u{2615}\u{2648}-\u{2653}\u{267F}\u{2693}\u{26A1}\u{26AA}-\u{26AB}\u{26BD}-\u{26BE}\u{26C4}-\u{26C5}\u{26CE}\u{26D4}\u{26EA}\u{26F2}-\u{26F3}\u{26F5}\u{26FA}\u{26FD}\u{2934}-\u{2935}\u{2B05}-\u{2B07}\u{2B1B}-\u{2B1C}\u{2B50}\u{2B55}\u{3030}\u{303D}\u{3297}\u{3299}]/gu;
 
-// Allow-list of Unicode ranges G2 can render. Anything outside gets stripped.
-//   \n\r\t           line break + tab (G2 respects \n in text containers)
-//   \x20-\x7E        printable ASCII
-//   \u00A0-\u00FF    Latin-1 Supplement
-//   \u2010-\u2027    general punctuation
-//   \u2030-\u205E    general punctuation (permille, primes, etc.)
-//   \u2190-\u21FF    arrows
-//   \u2500-\u257F    box drawing
-//   \u3000-\u303F    CJK symbols & punctuation
-//   \u3040-\u309F    Hiragana
-//   \u30A0-\u30FF    Katakana
-//   \u31F0-\u31FF    Katakana phonetic extensions
-//   \u3400-\u4DBF    CJK unified ideographs extension A
-//   \u4E00-\u9FFF    CJK unified ideographs
-//   \uF900-\uFAFF    CJK compatibility ideographs
-//   \uFF00-\uFFEF    half-width / full-width forms
+// Allow-list: printable ASCII, Latin-1 Supplement, general punctuation,
+// arrows, box drawing, CJK (symbols, Hiragana, Katakana, Han ideographs,
+// compatibility ideographs, half/full-width forms), and whitespace (\n\r\t).
 const UNSUPPORTED_RE = /[^\n\r\t\x20-\x7E\u00A0-\u00FF\u2010-\u2027\u2030-\u205E\u2190-\u21FF\u2500-\u257F\u3000-\u303F\u3040-\u309F\u30A0-\u30FF\u31F0-\u31FF\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF\uFF00-\uFFEF]/g;
 
 /**
  * Clean text for safe rendering on the G2 glasses display.
- * Strips emojis and unsupported Unicode characters, and normalizes whitespace.
+ * Strips emojis, unsupported Unicode characters, and normalizes whitespace.
  */
 export function cleanForG2(text: string): string {
   return text

--- a/glasses/text-clean.ts
+++ b/glasses/text-clean.ts
@@ -1,10 +1,6 @@
 /**
  * Text cleaning utilities for G2 glasses display.
  *
- * The G2 supports basic Latin, Latin-1 Supplement, and common symbols.
- * These helpers strip emojis, unsupported Unicode, and normalize whitespace
- * so text renders cleanly on the monospace G2 display.
- *
  * Usage:
  *   import { cleanForG2, normalizeWhitespace } from 'even-toolkit/text-clean';
  *   const safe = cleanForG2('Hello 🌍 World!');  // "Hello World!"
@@ -13,19 +9,34 @@
 // Match emoji ranges + misc symbols + dingbats + variation selectors
 const EMOJI_RE = /[\u{1F600}-\u{1F64F}\u{1F300}-\u{1F5FF}\u{1F680}-\u{1F6FF}\u{1F1E0}-\u{1F1FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}\u{FE00}-\u{FE0F}\u{200D}\u{20E3}\u{E0020}-\u{E007F}\u{1F900}-\u{1F9FF}\u{1FA00}-\u{1FA6F}\u{1FA70}-\u{1FAFF}\u{2702}-\u{27B0}\u{231A}-\u{231B}\u{23E9}-\u{23F3}\u{23F8}-\u{23FA}\u{25AA}-\u{25AB}\u{25B6}\u{25C0}\u{25FB}-\u{25FE}\u{2614}-\u{2615}\u{2648}-\u{2653}\u{267F}\u{2693}\u{26A1}\u{26AA}-\u{26AB}\u{26BD}-\u{26BE}\u{26C4}-\u{26C5}\u{26CE}\u{26D4}\u{26EA}\u{26F2}-\u{26F3}\u{26F5}\u{26FA}\u{26FD}\u{2934}-\u{2935}\u{2B05}-\u{2B07}\u{2B1B}-\u{2B1C}\u{2B50}\u{2B55}\u{3030}\u{303D}\u{3297}\u{3299}]/gu;
 
-// G2 supports basic Latin, Latin-1 Supplement, and some common symbols.
-// Strip anything outside printable ASCII + common Latin extended + box drawing.
-const UNSUPPORTED_RE = /[^\x20-\x7E\u00A0-\u00FF\u2010-\u2027\u2030-\u205E\u2190-\u21FF\u2500-\u257F]/g;
+// Allow-list of Unicode ranges G2 can render. Anything outside gets stripped.
+//   \n\r\t           line break + tab (G2 respects \n in text containers)
+//   \x20-\x7E        printable ASCII
+//   \u00A0-\u00FF    Latin-1 Supplement
+//   \u2010-\u2027    general punctuation
+//   \u2030-\u205E    general punctuation (permille, primes, etc.)
+//   \u2190-\u21FF    arrows
+//   \u2500-\u257F    box drawing
+//   \u3000-\u303F    CJK symbols & punctuation
+//   \u3040-\u309F    Hiragana
+//   \u30A0-\u30FF    Katakana
+//   \u31F0-\u31FF    Katakana phonetic extensions
+//   \u3400-\u4DBF    CJK unified ideographs extension A
+//   \u4E00-\u9FFF    CJK unified ideographs
+//   \uF900-\uFAFF    CJK compatibility ideographs
+//   \uFF00-\uFFEF    half-width / full-width forms
+const UNSUPPORTED_RE = /[^\n\r\t\x20-\x7E\u00A0-\u00FF\u2010-\u2027\u2030-\u205E\u2190-\u21FF\u2500-\u257F\u3000-\u303F\u3040-\u309F\u30A0-\u30FF\u31F0-\u31FF\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF\uFF00-\uFFEF]/g;
 
 /**
  * Clean text for safe rendering on the G2 glasses display.
- * Strips emojis, unsupported Unicode characters, and normalizes whitespace.
+ * Strips emojis and unsupported Unicode characters, and normalizes whitespace.
  */
 export function cleanForG2(text: string): string {
   return text
     .replace(EMOJI_RE, '')
     .replace(UNSUPPORTED_RE, '')
-    .replace(/\s+/g, ' ')
+    .replace(/[ \t]+/g, ' ')
+    .replace(/\n{3,}/g, '\n\n')
     .trim();
 }
 


### PR DESCRIPTION
Fixes #2

## Summary

Extend the `UNSUPPORTED_RE` allow-list in `glasses/text-clean.ts` so that
`cleanForG2()` preserves CJK characters (Hiragana, Katakana, Han ideographs,
full-width forms) and intentional newlines.

## Changes

- Add CJK Unicode ranges to the allow-list:
  `U+3000-303F` (CJK symbols & punctuation), `U+3040-309F` (Hiragana),
  `U+30A0-30FF` (Katakana), `U+31F0-31FF` (Katakana extensions),
  `U+3400-4DBF` (CJK unified ideographs ext. A), `U+4E00-9FFF` (CJK unified ideographs),
  `U+F900-FAFF` (CJK compatibility ideographs), `U+FF00-FFEF` (half/full-width forms)
- Preserve `\n`, `\r`, `\t` (G2 text containers honour `\n` as line break)
- Replace `\s+ → ' '` with `[ \t]+ → ' '` and `\n{3,} → '\n\n'` so
  intentional newlines survive

## Before / After

| Input | Before (v1.7.0) | After |
|---|---|---|
| `こんにちは世界 🌏` | `""` | `"こんにちは世界"` |
| `令和8年4月9日(木)\n丙午 月齢21.0` | `"849() 21.0"` | `"令和8年4月9日(木)\n丙午 月齢21.0"` |
| `「テスト」です。全角ＡＢＣ１２３` | `""` | `"「テスト」です。 全角ＡＢＣ１２３"` |
| `Hello 🌍 world\n日本語🎌と英語` | `"Hello world"` | `"Hello world\n日本語と英語"` |
| `ASCII only text\nShould be identical` | `"ASCII only textShould be identical"` | `"ASCII only text\nShould be identical"` |

Emojis remain stripped in both versions.

## Verification

Tested on real G2 hardware — Japanese text pushed via
`TextContainerProperty.content` renders correctly without custom fonts or
preprocessing.

<!-- comparison screenshots to be attached -->